### PR TITLE
Add --nmagic linker arg, for unaligned flash origin support.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -10,6 +10,10 @@
 # runner = "gdb -q -x openocd.gdb"
 
 rustflags = [
+  # This is needed if your flash or ram addresses are not aligned to 0x10000 in memory.x
+  # See https://github.com/rust-embedded/cortex-m-quickstart/pull/95
+  "-C", "link-arg=--nmagic",
+
   # LLD (shipped with the Rust toolchain) is used as the default linker
   "-C", "link-arg=-Tlink.x",
 


### PR DESCRIPTION
Without this, the linker places some extra program header entries that can confuse flashing tools.

Many thanks to @jonas-schievink for pointing me to this flag in Matrix.

**How to reproduce the bug**

- `cargo generate --git https://github.com/rust-embedded/cortex-m-quickstart`
- change flash `ORIGIN = 0x00027000` in `memory.x`
- `cargo build`
- `llvm-objdump -x target/thumbv7em-none-eabihf/debug/repro`

Program header entries will look something like this:

```
Program Header:
    PHDR off    0x00000034 vaddr 0x00020034 paddr 0x00020034 align 2**2
         filesz 0x00000100 memsz 0x00000100 flags r--
    LOAD off    0x00000000 vaddr 0x00020000 paddr 0x00020000 align 2**16
         filesz 0x00000134 memsz 0x00000134 flags r--
    LOAD off    0x00007000 vaddr 0x00027000 paddr 0x00027000 align 2**16
         filesz 0x00000400 memsz 0x00000400 flags r--
    LOAD off    0x00007400 vaddr 0x00027400 paddr 0x00027400 align 2**16
         filesz 0x00000570 memsz 0x00000570 flags r-x
    LOAD off    0x00007970 vaddr 0x00027970 paddr 0x00027970 align 2**16
         filesz 0x00000180 memsz 0x00000180 flags r--
   STACK off    0x00000000 vaddr 0x00000000 paddr 0x00000000 align 2**64
         filesz 0x00000000 memsz 0x00000000 flags rw-
```

The entry at 0x00020000 causes flashing tools (probe-rs at least) to flash data at 0x00020000, corrupting whatever's there. This happens whenever flash ORIGIN is not a multiple of 0x10000.

With `--nmagic`, program headers are correct and flashing does what it's supposed to do:

```
Program Header:
    LOAD off    0x000000f4 vaddr 0x00027000 paddr 0x00027000 align 2**2
         filesz 0x00000400 memsz 0x00000400 flags r--
    LOAD off    0x000004f4 vaddr 0x00027400 paddr 0x00027400 align 2**2
         filesz 0x00000570 memsz 0x00000570 flags r-x
    LOAD off    0x00000a64 vaddr 0x00027970 paddr 0x00027970 align 2**2
         filesz 0x00000180 memsz 0x00000180 flags r--
   STACK off    0x00000000 vaddr 0x00000000 paddr 0x00000000 align 2**64
         filesz 0x00000000 memsz 0x00000000 flags rw-
```